### PR TITLE
优化处理：

### DIFF
--- a/APDPlat_Core/src/main/java/org/apdplat/platform/log/APDPlatLoggerFactory.java
+++ b/APDPlat_Core/src/main/java/org/apdplat/platform/log/APDPlatLoggerFactory.java
@@ -32,12 +32,19 @@ public class APDPlatLoggerFactory {
     
     private APDPlatLoggerFactory() {
     }
-    
-    public static synchronized APDPlatLogger getAPDPlatLogger(Class clazz) {
+
+    public static APDPlatLogger getAPDPlatLogger(Class clazz) {
         APDPlatLogger log = CACHE.get(clazz);
+
         if(log == null){
-            log = new APDPlatLoggerImpl(clazz);
-            CACHE.put(clazz, log);
+            synchronized(clazz) {
+                if(!CACHE.containsKey(clazz)) {
+                    log = new APDPlatLoggerImpl(clazz);
+                    CACHE.put(clazz, log);
+                }else{
+                    log = CACHE.get(clazz);
+                }
+            }
         }
         return log;
     }


### PR DESCRIPTION
问题1：APDPlatLogger.getAPDPlatLogger(Class clazz)使用过于频繁，如果直接在getAPDPlatLogger方法上加synchronized，会严重影响应用的速度，

原因：
对于99%的调用只会执行到CACHE.get()一句，

所以
建议对1%CACHE.put()方法进行同步(synchronized)处理
# 

问题2(讨论－未修改)：
CACHE的KEY建议不要使用class的引用

原因：
由于CACHE的key存的是class的引用，当class不再须要，理论上是可以进行垃圾回收，但是CACHE中存的是该类的引用，所以导致垃圾回收不了（如果后期 扩展模块插件化(模块动态的卸载或安装)，将是一个潜在的问题）

如果使用字符串，则会吃内存
# 
