### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/APDPlat_Core/pom.xml
+++ b/APDPlat_Core/pom.xml
@@ -58,7 +58,7 @@
         <freemarker.version>2.3.15</freemarker.version>
         <commons-io.version>2.0.1</commons-io.version>
         <commons-fileupload.version>1.2.2</commons-fileupload.version>
-        <commons-collections.version>3.2.1</commons-collections.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <commons-codec.version>1.4</commons-codec.version>
         <commons-lang.version>2.5</commons-lang.version>
         <ognl.version>3.0.1</ognl.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/