### PR TITLE
[SECURITY] Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/APDPlat_Core/pom.xml
+++ b/APDPlat_Core/pom.xml
@@ -120,7 +120,7 @@
 		<repository>
 			<id>alimaven</id>
 			<name>aliyun maven</name>
-			<url>http://maven.aliyun.com/nexus/content/groups/public/</url>
+			<url>https://maven.aliyun.com/nexus/content/groups/public/</url>
 		</repository>
 		<repository>
 			<id>spring-releases</id>
@@ -133,12 +133,12 @@
 		<repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Framework Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 		</repository>
         <repository>
             <id>offical</id>
             <name>Maven Official Repository</name>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -146,7 +146,7 @@
         <repository>
             <id>jboss</id>
             <name>Jboss Repository</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -154,7 +154,7 @@
         <repository>
             <id>java.net</id>
             <name>Java.net Repository</name>
-            <url>http://download.java.net/maven/2/</url>
+            <url>https://download.java.net/maven/2/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -168,7 +168,7 @@
 		<pluginRepository>
 			<id>alimaven</id>
 			<name>aliyun maven</name>
-			<url>http://maven.aliyun.com/nexus/content/groups/public/</url>
+			<url>https://maven.aliyun.com/nexus/content/groups/public/</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>spring-releases</id>
@@ -181,12 +181,12 @@
 		<pluginRepository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Framework Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 		</pluginRepository>
         <pluginRepository>
             <id>offical</id>
             <name>Maven Official Repository</name>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -194,12 +194,12 @@
         <pluginRepository>
             <name>oss.sonatype.org</name>
             <id>oss.sonatype.org</id>
-            <url>http://oss.sonatype.org/content/groups/public</url>
+            <url>https://oss.sonatype.org/content/groups/public</url>
         </pluginRepository>
         <pluginRepository>
             <id>codehaus-snapshots</id>
             <name>Codehaus Snapshots</name>
-            <url>http://nexus.codehaus.org/snapshots/</url>
+            <url>https://nexus.codehaus.org/snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
{"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"A pull request already exists for JLLeitschuh:fix/JLL/use_https_to_resolve_dependencies_maven."}],"documentation_url":"https://docs.github.com/rest/reference/pulls#create-a-pull-request"}